### PR TITLE
相手をトーク一覧から非表示にする機能を追加

### DIFF
--- a/app/Http/Controllers/TalkController.php
+++ b/app/Http/Controllers/TalkController.php
@@ -50,14 +50,17 @@ class TalkController extends Controller
      */
     public function store($id)
     {
-        // 過去のトークがあるか検索
-        $group = Group::whereIn('id',Member::whereIn('user_id', Member::where('user_id',auth()->user()->id)->pluck('group_id'))
-        ->where('user_id', $id)
-        ->pluck('group_id'))
-        ->where('type','0')
-        ->first();
-        dd($group);
+        // 過去のトークがあるか検索(SQL発行回数一回ver.)
+        // $group = Group::whereIn('id',Member::whereIn('user_id', Member::where('user_id',auth()->user()->id)->pluck('group_id'))
+        // ->where('user_id', $id)
+        // ->pluck('group_id'))
+        // ->where('type','0')
+        // ->first();
 
+        // 過去のトークがあるか検索(SQL発行回数複数回ver.)
+        $userGroupId = Member::where('user_id',auth()->user()->id)->get(['group_id']);
+        $groupId = Member::whereIn('group_id', $userGroupId)->where('user_id', $id)->get(['group_id']);
+        $group = Group::whereIn('id', $groupId)->where('type','0')->first();
 
         if($group != null) {
             return redirect()->route('talk.show',$group->id);
@@ -95,7 +98,7 @@ class TalkController extends Controller
         $group = Group::find($groupId);
 
         // 非表示フラグを0（表示）にする処理
-        $member = Member::where('group_id',$groupId)->where('user_id',auth()->id())->first();
+        $member = Member::where('group_id',$groupId)->whereNot('user_id',auth()->id())->first();
         $member->invisible = 0;
         $member->save();
 

--- a/app/Http/Controllers/TalkController.php
+++ b/app/Http/Controllers/TalkController.php
@@ -39,10 +39,7 @@ class TalkController extends Controller
      */
     public function create()
     {
-        // // トーク開始画面を表示
-        // $friends = Friend::where('user_id', auth()->user()->id)->get();
-        // return view('talk.create', compact('friends'));
-        // // ->with('group',$group)
+        // 
     }
 
     /**
@@ -54,12 +51,13 @@ class TalkController extends Controller
     public function store($id)
     {
         // 過去のトークがあるか検索
-        $group = Group::
-        whereIn('id',Member::whereIn('user_id', Member::where('user_id',auth()->user()->id)->pluck('group_id'))
+        $group = Group::whereIn('id',Member::whereIn('user_id', Member::where('user_id',auth()->user()->id)->pluck('group_id'))
         ->where('user_id', $id)
         ->pluck('group_id'))
         ->where('type','0')
         ->first();
+        dd($group);
+
 
         if($group != null) {
             return redirect()->route('talk.show',$group->id);
@@ -95,6 +93,12 @@ class TalkController extends Controller
     {   
         $groupId = $id;
         $group = Group::find($groupId);
+
+        // 非表示フラグを0（表示）にする処理
+        $member = Member::where('group_id',$groupId)->where('user_id',auth()->id())->first();
+        $member->invisible = 0;
+        $member->save();
+
         $dialogUser = User::whereIn('id', Member::where('group_id', $groupId)->where('user_id', '!=', auth()->user()->id)->pluck('user_id'))->first();
 
         return view('talk.show', compact('group', 'dialogUser'));
@@ -120,7 +124,12 @@ class TalkController extends Controller
      */
     public function update(Request $request, $id)
     {
-        //
+        // トークを非表示にするよう表示フラグを変更
+        $member = Member::find($id);
+        $member->invisible = 1;
+        $member->save();
+
+        return redirect()->route('talk.index');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,7 +48,7 @@ class User extends Authenticatable
 
     // Userテーブルと結合.
     public function group() {
-        return $this->belongsToMany(Group::class);
+        return $this->belongsTo(Group::class);
     }
 
     public function friends() {

--- a/resources/views/friend/index.blade.php
+++ b/resources/views/friend/index.blade.php
@@ -58,9 +58,9 @@
                     </div>
                     {{-- トークする --}}
                     <div class="my-10 ml-auto mr-10">
-                        <form method="GET" action="{{ route('talk.store', $friend->follow_id) }}">
+                        <form method="GET" action={{ route('talk.store', $friend->follow_id) }} >
                             <button
-                                class="bg-transparent hover:bg-slate-700 text-slate-500 font-semibold hover:text-slate-700 py-4 px-4 border border-slate-700 hover:border-transparent rounded">
+                                class="bg-amber-300 hover:bg-amber-500 text-white font-semibold hover:text-slate-700 py-4 px-4 border border-slate-700 hover:border-transparent rounded">
                                 トークする
                             </button>
                         </form>

--- a/resources/views/talk/index.blade.php
+++ b/resources/views/talk/index.blade.php
@@ -23,6 +23,7 @@
     <div class="py-12">
 
         @foreach ($groups as $group)
+            @if($group->invisible == 0)
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 py-1">
                 <a href="/talk/show/{{ $group->group_id }}">
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg flex">
@@ -46,11 +47,18 @@
                                 @endif
                             </div>
                         </div>
+                        {{-- 非表示ボタン --}}
+                        <div class="my-10 ml-auto mr-10">
+                            <form action={{ route('talk.update',$group->id) }}>
+                                <button class="bg-transparent hover:bg-slate-700 text-slate-500 font-semibold hover:text-slate-700 py-4 px-4 border border-slate-700 hover:border-transparent rounded" name="invisible" type="submit">
+                                    非表示にする
+                                </button>
+                            </form>
+                        </div>
                     </div>
                 </a>
             </div>
+            @endif
         @endforeach
-    </div>
-
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,6 +67,9 @@ Route::group(['middleware' => 'auth'], function () {
     // トーク画面を表示する
     Route::get('/talk/show/{id}', [App\Http\Controllers\TalkController::class, "show"])->name('talk.show');
 
+    // トークを非表示にする
+    Route::get('/talk/update/{id}',[App\Http\Controllers\TalkController::class, "update"])->name('talk.update');
+
     Route::get('/friend/index', [App\Http\Controllers\FriendController::class, 'index'])->name('friend.index');
     // Route::resource('friend', FriendController::class);
 


### PR DESCRIPTION
相手をトーク一覧から非表示にする機能を実装しました。
また一度非表示にしても再度フレンズ一覧からトークを始めると過去のトークを表示させ、トーク一覧にも表示されるよう作成しました。
ご確認いただき問題なければマージをお願いいたします。